### PR TITLE
DLO-60 Amplification Limit fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link
   rel="stylesheet"
   href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"

--- a/src/AmplificationTile.js
+++ b/src/AmplificationTile.js
@@ -93,7 +93,7 @@ const AplificationTile = props => {
   const setAmplificationType = (index, type, icon) => {
     selected[index].type = type;
     selected[index].icon = icon;
-    console.log(selected);
+
     handleClose();
   };
   function handleClick(event, index) {
@@ -181,7 +181,7 @@ const AplificationTile = props => {
                         color: "#ffffff67"
                       }}
                     >
-                      <Icon color="#fff">{selected[i].icon}</Icon>
+                      <Icon>{selected[i].icon}</Icon>
                     </Avatar>
                   ) : null
                 }

--- a/src/AmplificationTile.js
+++ b/src/AmplificationTile.js
@@ -18,7 +18,9 @@ import ListItemIcon from "@material-ui/core/ListItemIcon";
 import ListItemText from "@material-ui/core/ListItemText";
 import { withStyles } from "@material-ui/core/styles";
 import Fab from "@material-ui/core/Fab";
-import theme from './styling/theme.scss';
+import theme from "./styling/theme.scss";
+import Icon from "@material-ui/core/Icon";
+
 const useStyles = makeStyles(theme => ({
   root: {
     display: "flex",
@@ -67,27 +69,34 @@ const AplificationTile = props => {
   const [anchorEl, setAnchorEl] = useState(null);
   const [currentSelection, setCurrentSelection] = useState(null);
   const [selected, pushSelected] = useState({});
+  const selectLimit =
+    props.words && props.words.keywords
+      ? props.words.keywords.length > 5
+        ? 3
+        : props.words.keywords.length === 1
+        ? 1
+        : Math.floor(props.words.keywords.length / 2)
+      : 0;
 
   const addSelect = idea => {
     selected[idea] = {
       type: "basic amplification",
-      keyword: props.words.keywords[idea]
+      keyword: props.words.keywords[idea],
+      icon: "cancel"
     };
     pushSelected(selected);
-
   };
   const deleteSelect = idea => {
     delete selected[idea];
     pushSelected({ ...selected });
-
   };
-  const setAmplificationType = (index, type) => {
+  const setAmplificationType = (index, type, icon) => {
     selected[index].type = type;
-
+    selected[index].icon = icon;
+    console.log(selected);
     handleClose();
   };
   function handleClick(event, index) {
-
     setAnchorEl(event.target);
     setCurrentSelection(index);
   }
@@ -136,7 +145,7 @@ const AplificationTile = props => {
                   aria-label="add"
                   className={classes.chip2}
                   classes={
-                    selected && Object.keys(selected).length == 3
+                    selected && Object.keys(selected).length == selectLimit
                       ? { root: "amplificationDone", sizeSmall: "smallFab" }
                       : {
                           root: "amplificationDoneDisabled",
@@ -167,9 +176,12 @@ const AplificationTile = props => {
                   selected && selected[i] ? (
                     <Avatar
                       className="amplificationChipAvatar"
-                      style={{ backgroundColor: theme.primary, color: "#ffffff67" }}
+                      style={{
+                        backgroundColor: theme.primary,
+                        color: "#ffffff67"
+                      }}
                     >
-                      <CancelIcon />
+                      <Icon color="#fff">{selected[i].icon}</Icon>
                     </Avatar>
                   ) : null
                 }
@@ -177,17 +189,17 @@ const AplificationTile = props => {
                 classes={
                   selected && selected[i]
                     ? { root: "chipClicked" }
-                    : selected && Object.keys(selected).length == 3
+                    : selected && Object.keys(selected).length == selectLimit
                     ? { root: "chipDisabled" }
                     : { root: "chipUnclicked" }
                 }
                 clickable
-                onClick={(event) => { return (
-                  selected && selected[i]
+                onClick={event => {
+                  return selected && selected[i]
                     ? deleteSelect(i)
-                    : selected && Object.keys(selected).length < 3
+                    : selected && Object.keys(selected).length < selectLimit
                     ? (addSelect(i), handleClick(event, i))
-                    : null);
+                    : null;
                 }}
               />
             ))
@@ -201,7 +213,9 @@ const AplificationTile = props => {
           classes={{ paper: "popMenu" }}
         >
           <StyledMenuItem
-            onClick={() => setAmplificationType(currentSelection, "colour")}
+            onClick={() =>
+              setAmplificationType(currentSelection, "colour", "color_lens")
+            }
           >
             <ListItemIcon>
               <ColorLensIcon />
@@ -209,7 +223,13 @@ const AplificationTile = props => {
             <ListItemText primary="Colour" />
           </StyledMenuItem>
           <StyledMenuItem
-            onClick={() => setAmplificationType(currentSelection, "highlight")}
+            onClick={() =>
+              setAmplificationType(
+                currentSelection,
+                "highlight",
+                "format_paint"
+              )
+            }
           >
             <ListItemIcon>
               <FormatPaintIcon />
@@ -217,7 +237,9 @@ const AplificationTile = props => {
             <ListItemText primary="Highlight" />
           </StyledMenuItem>
           <StyledMenuItem
-            onClick={() => setAmplificationType(currentSelection, "move")}
+            onClick={() =>
+              setAmplificationType(currentSelection, "move", "control_camera")
+            }
           >
             <ListItemIcon>
               <ControlCameraIcon />
@@ -225,7 +247,9 @@ const AplificationTile = props => {
             <ListItemText primary="Move" />
           </StyledMenuItem>
           <StyledMenuItem
-            onClick={() => setAmplificationType(currentSelection, "enlarge")}
+            onClick={() =>
+              setAmplificationType(currentSelection, "enlarge", "zoom_out_map")
+            }
           >
             <ListItemIcon>
               <ZoomIcon />
@@ -234,11 +258,11 @@ const AplificationTile = props => {
           </StyledMenuItem>
         </StyledMenu>
       </Col>
-      {props.last ? null : (
+      {/* {props.last || !(props.words && props.words.keywords) ? null : (
         <div className={props.active ? "outer" : "outerClosed"}>
           <div className={props.active ? "inner" : "innerClosed"}></div>
         </div>
-      )}
+      )} */}
     </Row>
   );
 };

--- a/src/style.scss
+++ b/src/style.scss
@@ -426,7 +426,7 @@ margin-left: 30px;
 .outer {
   z-index: 1;
   width: 4px;
-  height: 400px;
+  height: 300px;
   position: absolute;
   overflow: hidden;
   margin-left: 52px;


### PR DESCRIPTION
### **Related Issue/Keyword:**
[DLO-60](https://trello.com/c/317LWefX)
### **Description:**
This Ticket is a parent ticket to [DLO-59](https://trello.com/c/5JhdYxIW). The tasks for both tickets are related and so they are both included in this PR.

The PR includes:
 - showing amplification type in the selected keyword chips
 - removing of the line that sometimes overflows from the last tile
 - adjusting the selection limit based on how many keywords are in each idea
### **Testing:**
 - No keywords allows you to move on to next idea
 - 1 keyword means you should have to select that one before you can move on
 - <= 5 keywords = 3 keyword selection restriction
    - else: keyword selection restriction = `floor(keyword.length/2)`


 - Check that the correct amp type is shown on the chip when chosen
    - cross is shown when no amp type is selected
### **Checklist:**

- [x] Latest master merged/rebased into your feature branch 
- [x] Meets the projects coding conventions
- [x] No out of scope changes
- [x] #Mentioned other relevant issues
- [x] No failure when running the application (obviously lol)