### PR TITLE
DLO-66 push notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13509,6 +13509,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-notifications-component": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-notifications-component/-/react-notifications-component-2.1.0.tgz",
+      "integrity": "sha512-qCjPVmrdz96t1/oOCdJzJYAAKha5r2LhiVcE2uM/3DIHOZlkQ0MqZtmoPzLiZoQ2kOUom5HeVX6gEbp+lRSnEw==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-overlays": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^16.9.0",
     "react-firebaseui": "^4.0.0",
     "react-ionicons": "^2.1.6",
+    "react-notifications-component": "^2.1.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.2",
     "retext": "^7.0.0",

--- a/src/Firestore.js
+++ b/src/Firestore.js
@@ -148,6 +148,11 @@ class Firestore {
         return db.collection("users").doc(userID).collection("sharedProjects").orderBy('shareTime', 'desc');
     };
 
+    static shareListener(userID) {
+        return db.collection("users").doc(userID).collection("sharedProjects");
+            
+    }
+
     static getUserEmails() {
         return db.collection("users").get();
     };

--- a/src/MailboxPopup.js
+++ b/src/MailboxPopup.js
@@ -3,46 +3,103 @@ import MailboxListBox from "./MailboxListBox";
 import { Modal, Button, ButtonToolbar } from "react-bootstrap";
 import IconButton from "@material-ui/core/IconButton";
 import NotificationIcon from "@material-ui/icons/Notifications";
+import Firestore from "./Firestore";
+import firebase from "firebase";
+import Badge from "@material-ui/core/Badge";
 import "./style.scss";
 import { withRouter, Redirect } from "react-router";
-
+import { notification } from "antd";
+import ReactNotification from 'react-notifications-component'
+import 'react-notifications-component/dist/theme.css'
+import { store } from 'react-notifications-component';
 class MailboxPopup extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { mailModalShow: false };
+    this.state = { mailModalShow: false, notification: false };
+    var user = firebase.auth().currentUser;
+    this.createFnCounter = this.createFnCounter.bind(this);
+    this.handleActivitySubscription = this.handleActivitySubscription.bind(this);
+    // Firestore.shareListener(user.uid).onSnapshot(() => {
+    //   this.setState({ notification: true });
+    // });
+
+    const handleActivitySubscriptionWithCounter = this.createFnCounter(this.handleActivitySubscription,1);
+    Firestore.shareListener(user.uid).onSnapshot(handleActivitySubscriptionWithCounter);
+  }
+
+  handleActivitySubscription(snapshot) {
+    this.setState({ notification: true });
+    snapshot.docChanges().forEach(function(change) {          
+      // console.log(change.doc.data());
+      store.addNotification({
+        title: change.doc.data().createUser + " shared a project with you!",
+        message: change.doc.data().medium + " project: " + change.doc.data().title,
+        type: "success",
+        insert: "top",
+        container: "top-right",
+        animationIn: ["animated", "fadeIn"],
+        animationOut: ["animated", "fadeOut"],
+        dismiss: {
+          duration: 5000,
+        }
+      });          
+    });
+
+    
+  }
+
+  createFnCounter(fn, invokeBeforeExecution) {
+    let count = 0;
+    return args => {
+      count++;
+      if (count <= invokeBeforeExecution) {
+        return true;
+      } else {
+        return fn(args, count);
+      }
+    };
   }
 
   toggleMailPopup() {
     this.setState({ mailModalShow: !this.state.mailModalShow });
+    this.setState({ notification: false });
   }
 
-  loadProject = (proj) => {
+  loadProject = proj => {
     const { history } = this.props;
     history.push({
-        pathname: "./project",
-        state: {
-          createUser: proj.createUser,
-          projectID: proj.id,
-          medium: proj.medium,
-          title: proj.title,
-          topic: proj.subtitle,
-          image: proj.title,
-          shared: true,
-          path: proj.path
-        }
-      });
+      pathname: "./project",
+      state: {
+        createUser: proj.createUser,
+        projectID: proj.id,
+        medium: proj.medium,
+        title: proj.title,
+        topic: proj.subtitle,
+        image: proj.title,
+        shared: true,
+        path: proj.path
+      }
+    });
     this.toggleMailPopup();
-  }
+  };
 
   render() {
     return (
+      
       <ButtonToolbar className="buttonToolbar">
+        <ReactNotification />
         <IconButton
           aria-label="notifications"
           onClick={() => this.toggleMailPopup()}
           className="bell"
         >
-          <NotificationIcon fontSize="default" />
+          <Badge
+            variant="dot"
+            color="error"
+            invisible={!this.state.notification}
+          >
+            <NotificationIcon fontSize="default" />
+          </Badge>
         </IconButton>
 
         <Modal
@@ -51,17 +108,16 @@ class MailboxPopup extends React.Component {
           size="lg"
           aria-labelledby="contained-modal-title-vcenter"
           centered
-          
         >
           <Modal.Header closeButton>
             <Modal.Title id="notifications">Notifications</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            <MailboxListBox pageSize={8} loadProject={this.loadProject}/>
+            <MailboxListBox pageSize={8} loadProject={this.loadProject} />
           </Modal.Body>
           <Modal.Footer>
             <Button
-            className="mailPopupButton"
+              className="mailPopupButton"
               onClick={() => this.toggleMailPopup()}
             >
               Close


### PR DESCRIPTION
### **Related Issue/Keyword:**
[DLO-66](https://trello.com/c/d7OQNlCE)
### **Description:**
> When a project is shared with another user, they get a notification as soon as it is shared.
This will add a bubble next to the bell icon when a new project is shared. it will also show a brief toast notification showing who shared what.
 ### bell with bubble
![Screen Shot 2019-09-27 at 5 58 32 PM](https://user-images.githubusercontent.com/17172036/65745646-7cdcf700-e150-11e9-9888-06eb9f57c578.png)
 ### toast notification
![Screen Shot 2019-09-27 at 5 58 43 PM](https://user-images.githubusercontent.com/17172036/65745647-7ea6ba80-e150-11e9-9e4e-630648df31e5.png)

### **Testing:**

 - this required a listener to be attached to the user's sharedProjects collection in firestore
    - maybe check to see whether the bandwidth usage is not negatively affected, as I do not detach this listener. 

 - check notifications come in
 - check bubble on bell is cleared when viewed inbox

 # `npm install`
### **Checklist:**

- [x] Latest master merged/rebased into your feature branch 
- [x] Meets the projects coding conventions
- [x] No out of scope changes
- [x] #Mentioned other relevant issues
- [x] No failure when running the application (obviously lol)