### PR TITLE
Dlo 66 detach the listener when unmount

### DIFF
--- a/src/MailboxPopup.js
+++ b/src/MailboxPopup.js
@@ -15,16 +15,13 @@ import { store } from 'react-notifications-component';
 class MailboxPopup extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { mailModalShow: false, notification: false };
     var user = firebase.auth().currentUser;
     this.createFnCounter = this.createFnCounter.bind(this);
     this.handleActivitySubscription = this.handleActivitySubscription.bind(this);
-    // Firestore.shareListener(user.uid).onSnapshot(() => {
-    //   this.setState({ notification: true });
-    // });
 
     const handleActivitySubscriptionWithCounter = this.createFnCounter(this.handleActivitySubscription,1);
-    Firestore.shareListener(user.uid).onSnapshot(handleActivitySubscriptionWithCounter);
+    const listener = Firestore.shareListener(user.uid).onSnapshot(handleActivitySubscriptionWithCounter);
+    this.state = { mailModalShow: false, notification: false, listener: listener };
   }
 
   handleActivitySubscription(snapshot) {
@@ -58,6 +55,10 @@ class MailboxPopup extends React.Component {
         return fn(args, count);
       }
     };
+  }
+
+  componentWillUnmount() {
+    this.state.listener();
   }
 
   toggleMailPopup() {


### PR DESCRIPTION
### **Related Issue/Keyword:**
DLO-66, detach the listener when unmount
### **Description:**
actually we need to detach the listener when unmount the notification component, otherwise after flipping through a list of pages, there are many listeners, then a sharing may cause multi notifications as below:
![image](https://user-images.githubusercontent.com/3829984/65810331-588b2400-e1fd-11e9-982e-227350963a72.png)

### **Testing:**
**Steps for manual testing:**

1. flipping through a list of different pages, then return to the home page or projects page
2. click a project to share, you may only receive one notification

### **Checklist:**

- [x] Latest master merged/rebased into your feature branch 
- [x] Meets the projects coding conventions
- [x] No out of scope changes
- [x] #Mentioned other relevant issues
- [x] No failure when running the application (obviously lol)